### PR TITLE
Fix source link of "pcre" and "zlib"

### DIFF
--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,7 @@ wget "http://nginx.org/download/nginx-1.7.8.tar.gz"
 # pcre 官网:
 # http://www.pcre.org/
 #
-wget "ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-8.38.tar.gz"
+wget "http://ftp.cs.stanford.edu/pub/exim/pcre/pcre-8.38.tar.gz"
 
 #
 # 下载最新版 openssl
@@ -63,7 +63,7 @@ wget "https://www.openssl.org/source/openssl-1.0.1j.tar.gz"
 # zlib 官网:
 # http://www.zlib.net/
 #
-wget "http://zlib.net/zlib-1.2.8.tar.gz"
+wget "http://zlib.net/fossils/zlib-1.2.8.tar.gz"
 
 #
 # 下载本扩展


### PR DESCRIPTION
Updated to the correct link of "pcre" and "zlib" with original version.