### PR TITLE
fix:id.google.com

### DIFF
--- a/src/ngx_http_google_inject.c
+++ b/src/ngx_http_google_inject.c
@@ -140,7 +140,7 @@ ngx_http_google_inject_subs(ngx_conf_t * cf)
     
     if (ngx_http_google_inject_subs_args(cf,
                                          "subs_filter", 3,
-                                         "((www)|(images))\\.google\\.[0-9a-z.]+",
+                                         "((www)|(images)|(id))\\.google\\.[0-9a-z.]+",
                                          "$google_host",
                                          "igr"))
       break;


### PR DESCRIPTION
 The proxy page is slow because id.google.com is blocked.